### PR TITLE
Checking if the current branch name starts with release.

### DIFF
--- a/src/git-ver-get-suffix
+++ b/src/git-ver-get-suffix
@@ -24,14 +24,14 @@ get_suffix() {
 
     if [[ "$branch_name" == master ]]; then 
         suffix=""
-    elif [[ "$branch_name" == "release/"* ]]; then 
+    elif [[ "$branch_name" == "release"* ]]; then 
         suffix="rc"
-    elif [[ "$branch_name" == develop ]]; then 
-        suffix="pre"
-    elif [[ "$branch_name" == "feature/"* ]]; then 
-        suffix="beta"; 
-    else
+    elif [[ "$branch_name" == "develop"* ]]; then 
+        suffix="beta"
+    elif [[ "$branch_name" == "feature"* ]]; then 
         suffix="alpha"; 
+    else
+        suffix="pre"; 
     fi
 
     if [[ ( "$1" == "--rev" || "$1" == "-r" ) && "$rev" -gt 0 && "$suffix" != "" ]]; then suffix="$suffix+r$rev"; fi

--- a/src/git-ver-get-version
+++ b/src/git-ver-get-version
@@ -2,12 +2,16 @@
 set -e
 ver=$(echo "$(git rev-parse --symbolic --tags | sed -e 's/\(.*\)\([-].*\)/\1/')" | sed 's/[^0-9.]//g' | sort -i | tail -1 )
 
-if [[ "$APPVEYOR" == true ]]; then
+branch_name=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$branch_name" == "release"* ]]; then 
+    ver="$( git rev-parse --abbrev-ref HEAD | sed -e 's/[^0-9.]//g')"
+elif [[ "$APPVEYOR" == true ]]; then
     ver=$APPVEYOR_BUILD_VERSION
 elif [[ "$VersionPrefix" != "" ]]; then
     ver=$VersionPrefix
 elif [[ "$Version" != "" ]]; then
     ver=$Version
 fi
+
 if [[ "$ver" == "" ]]; then ver="0.0.1"; fi
 echo $ver

--- a/src/git-ver-help-get-suffix
+++ b/src/git-ver-help-get-suffix
@@ -24,9 +24,9 @@ To establish a suffix, the following steps are taken.
     3. If no tag suffix is extract, the branch name is used instead.
     4. The master branch gets no suffix. Only actual releases happen from it.
     5. A branch with a name starting with release gets the suffix of -rc
-    6. A branch with a name starting with develop gets the suffix of -pre
-    7. A branch with a name starting with feature gets the suffix of -beta
-    8. All other branches get a suffix of -alpha
+    6. A branch with a name starting with develop gets the suffix of -beta
+    7. A branch with a name starting with feature gets the suffix of -alpha
+    8. All other branches get a suffix of -pre
 
 There are two additional optional meta data parameters.
     -r | --rev  : This includes the results of git-ver get-rev as metadata after the main part of the suffix. For example: -rc+5

--- a/src/git-ver-help-get-version
+++ b/src/git-ver-help-get-version
@@ -27,6 +27,7 @@ If a suitable version is extracted from a tag it becomes the candidate version n
     1. An APP_VEYOR_VERSION environment variable is set. 
     2. OR A VersionPrefix environment variable is set. 
     3. OR A Version environment variable is set.
+    4. OR The current branch name starts with release
 
 The contents of the environment variable are assumed to match the MAJOR.MINOR.PATCH format. Ensure that they do.
 


### PR DESCRIPTION
Use the release branch version number for the base version number.


