### PR TITLE
fixed an issue with the text in INSTALLING.md referencing jcd-new instead of git-ver

### DIFF
--- a/src/INSTALLING.md
+++ b/src/INSTALLING.md
@@ -1,19 +1,19 @@
-# Installing `jcd-new` from a zip file.
+# Installing `git-ver` from a zip file.
 * First unzip the release you got from GitHub to a location of your choosing.
 * Then cd into that directory and execute install.sh
 
 ## Example
 ```bash
 # On linux, in the directory you downloaded the zip file to, and with the unzip command already installed.
-unzip jcd-new_v0.0.2.zip -d ./jcd-new_v0.0.2
-cd jcd-new_v0.0.2
+unzip git-ver_v0.0.2.zip -d ./git-ver_v0.0.2
+cd git-ver_v0.0.2
 
 # Install to your personal bin folder, which you already have in your PATH.
 bash ./install.sh ~/bin
 
 # Now verify the installation worked. NOTE: This won't work if ~/bin isn't in your PATH.
-jcd-new --version
+git-ver --version
 ```
 
-# Uninstalling `jcd-new`
-Delete the files from the locations listed from running `jcd-new locations`.
+# Uninstalling `git-ver`
+Delete the files from the locations listed from running `git-ver show-locations`.


### PR DESCRIPTION
## Description

fixed an issue with the text in INSTALLING.md referencing jcd-new instead of git-ver

## Type of change

- [X] Bug fix 

## How Has This Been Tested?
I read the documentation this time... oops for last time.

**Test Configuration**:
N/A

## Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
